### PR TITLE
Mux compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ mux := http.NewServeMux()
 group := routegroup.New(mux)
 group.Route(func(b *routegroup.Bundle) {
     b.Use(loggingMiddleware, corsMiddleware)
-    b.HandleFunc("GET /hello", helloHandler)
-    b.HandleFunc("GET /bye", byeHandler)
+    b.Handle("GET /hello", helloHandler)
+    b.Handle("GET /bye", byeHandler)
 })
 http.ListenAndServe(":8080", mux)
 ```
@@ -122,8 +122,8 @@ mux.Use(loggingMiddleware, corsMiddleware)
 // this group will inherit the middlewares from the base group
 apiGroup := mux.Group()
 apiGroup.Use(apiMiddleware)
-apiGroup.HandleFunc("GET /hello", helloHandler)
-apiGroup.HandleFunc("GET /bye", byeHandler)
+apiGroup.Handle("GET /hello", helloHandler)
+apiGroup.Handle("GET /bye", byeHandler)
 
 
 // mount another group for the /admin path with its own set of middlewares, 
@@ -131,7 +131,7 @@ apiGroup.HandleFunc("GET /bye", byeHandler)
 // this group will inherit the middlewares from the base group as well
 mux.Mount("/admin").Route(func(b *routegroup.Bundle) {
     b.Use(adminMiddleware)
-    b.HandleFunc("POST /do", doHandler)
+    b.Handle("POST /do", doHandler)
 })
 
 // start the server, passing the wrapped mux as the handler
@@ -197,8 +197,6 @@ func (s *Service) fileServerHandlerFunc() http.HandlerFunc {
         webFS.ServeHTTP(w, r)
     }
 }
-
-
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Simple and intuitive API for route grouping and route mounting.
 - Easy middleware integration for individual routes or groups of routes.
 - Seamless integration with Go's standard `http.ServeMux`.
+- Fully compatible with the `http.Handler` interface and can be used as a drop-in replacement for `http.ServeMux`.
 
 ## Install and update
 
@@ -69,14 +70,14 @@ func main() {
 	apiGroup.Use(loggingMiddleware, corsMiddleware)
 
 	// route handling
-	apiGroup.Handle("GET /hello", func(w http.ResponseWriter, r *http.Request) {
+	apiGroup.HandleFunc("GET /hello", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello, API!"))
 	})
 	
 	// add another group with its own set of middlewares
 	protectedGroup := apiGroup.Group()
 	protectedGroup.Use(authMiddleware)
-	protectedGroup.Handle("GET /protected", func(w http.ResponseWriter, r *http.Request) {
+	protectedGroup.HandleFunc("GET /protected", func(w http.ResponseWriter, r *http.Request) {
         w.Write([]byte("Protected API!"))
     })
 
@@ -101,15 +102,15 @@ mux := http.NewServeMux()
 group := routegroup.New(mux)
 group.Route(func(b *routegroup.Bundle) {
     b.Use(loggingMiddleware, corsMiddleware)
-    b.Handle("GET /hello", helloHandler)
-    b.Handle("GET /bye", byeHandler)
+    b.HandleFunc("GET /hello", helloHandler)
+    b.HandleFunc("GET /bye", byeHandler)
 })
 http.ListenAndServe(":8080", mux)
 ```
 
 ### Using derived groups
 
-In some instances, it's practical to create an initial group that includes a set of middlewares, and then derive all other groups from it. This approach guarantees that every group incorporates a common set of middlewares as a foundation, allowing each to add its specific middlewares. To facilitate this scenario, `routegrou`p offers both `Bundle.Group` and `Bundle.Mount` methods, and it also implements the `http.Handler` interface. The following example illustrates how to utilize derived groups:
+In some instances, it's practical to create an initial group that includes a set of middlewares, and then derive all other groups from it. This approach guarantees that every group incorporates a common set of middlewares as a foundation, allowing each to add its specific middlewares. To facilitate this scenario, `routegroup` offers both `Bundle.Group` and `Bundle.Mount` methods, and it also implements the `http.Handler` interface. The following example illustrates how to use derived groups:
 
 ```go
 // create a new bundle with a base set of middlewares
@@ -121,8 +122,8 @@ mux.Use(loggingMiddleware, corsMiddleware)
 // this group will inherit the middlewares from the base group
 apiGroup := mux.Group()
 apiGroup.Use(apiMiddleware)
-apiGroup.Handle("GET /hello", helloHandler)
-apiGroup.Handle("GET /bye", byeHandler)
+apiGroup.HandleFunc("GET /hello", helloHandler)
+apiGroup.HandleFunc("GET /bye", byeHandler)
 
 
 // mount another group for the /admin path with its own set of middlewares, 
@@ -130,7 +131,7 @@ apiGroup.Handle("GET /bye", byeHandler)
 // this group will inherit the middlewares from the base group as well
 mux.Mount("/admin").Route(func(b *routegroup.Bundle) {
     b.Use(adminMiddleware)
-    b.Handle("POST /do", doHandler)
+    b.HandleFunc("POST /do", doHandler)
 })
 
 // start the server, passing the wrapped mux as the handler
@@ -157,30 +158,30 @@ func (s *Service) Routes() http.Handler {
 	csrfMiddleware := s.middleware.csrf(s.skipCSRFCheck)
 
 	// add open routes
-	router.Handle("GET /login", s.loginPageHandler)
-	router.Handle("POST /login", s.loginCheckHandler)
-	router.Handle("GET /logout", s.logoutHandler)
+	router.HandleFunc("GET /login", s.loginPageHandler)
+	router.HandleFunc("POST /login", s.loginCheckHandler)
+	router.HandleFunc("GET /logout", s.logoutHandler)
 
 	// add routes with auth middleware
 	router.Group().Route(func(auth *routegroup.Bundle) {
 		auth.Use(s.middleware.Auth())
-		auth.Handle("GET /update", s.pwdUpdateHandler)
-		auth.With(csrfMiddleware).Handle("PUT /update", s.pwdUpdateHandler)
+		auth.HandleFunc("GET /update", s.pwdUpdateHandler)
+		auth.With(csrfMiddleware).HandleFunc("PUT /update", s.pwdUpdateHandler)
 	})
 
 	// add admin routes
 	router.Mount("/admin").Route(func(admin *routegroup.Bundle) {
 		admin.Use(s.middleware.Auth("admin"))
 		admin.Use(s.middleware.AdminOnly)
-		admin.Handle("GET /", s.admin.renderHandler)
+		admin.HandleFunc("GET /", s.admin.renderHandler)
 		admin.With(csrfMiddleware).Route(func(csrf *routegroup.Bundle) {
-			csrf.Handle("DELETE /sessions", s.admin.deleteSessionsHandler)
-			csrf.Handle("POST /user", s.admin.addUserHandler)
-			csrf.Handle("DELETE /user", s.admin.deleteUserHandler)
+			csrf.HandleFunc("DELETE /sessions", s.admin.deleteSessionsHandler)
+			csrf.HandleFunc("POST /user", s.admin.addUserHandler)
+			csrf.HandleFunc("DELETE /user", s.admin.deleteUserHandler)
 		})
 	})
 
-	router.Handle("GET /static/*", s.fileServerHandlerFunc()) // serve static files
+	router.HandleFunc("GET /static/*", s.fileServerHandlerFunc()) // serve static files
 	return router
 }
 


### PR DESCRIPTION
This PR is to make `routegroup.Bundle` more compatible with the standard mux.

1. Change `Handle` func to accept `http.Handler`, not `http.HandlerFunc` like it was before. This is a breaking change
2. Add `HandlerFunc` accepting ` `http.HandlerFunc` as a parameter
3. Add `Handler` to locate  the handler and the pattern that matches the request

_The result of this change is fill compatibility between `http.SeverMux`  and `routegroup.Bundle`_