### PR TITLE
Add the ability to set a custom not-found handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ func main() {
     group := routegroup.New(mux)
 }
 ```
+** Setting optional `NotFoundHandler`**
+
+It is possible to set a custom `NotFoundHandler` for the group. This handler will be called when no other route matches the request:
+
+```go
+    group.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        http.Error(w, "404 page not found, something is wrong!", http.StatusNotFound)
+    })
+```
+
+If the custom `NotFoundHandler` is not set, `routegroup` will automatically use a default handler from stdlib (`http.NotFoundHandler()`). 
 
 **Adding Routes with Middleware**
 

--- a/group_test.go
+++ b/group_test.go
@@ -800,6 +800,153 @@ func TestHTTPServerWithDerived(t *testing.T) {
 	})
 }
 
+func TestHTTPServerWithCustomNotFound(t *testing.T) {
+	group := routegroup.New(http.NewServeMux())
+	group.Use(testMiddleware)
+	group.NotFoundHandler(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "Custom 404: Page not found!", http.StatusNotFound)
+	})
+
+	apiGroup := group.Mount("/api")
+	apiGroup.HandleFunc("GET /test", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("test handler"))
+	})
+
+	testServer := httptest.NewServer(group)
+	defer testServer.Close()
+
+	t.Run("GET /api/test", func(t *testing.T) {
+		resp, err := http.Get(testServer.URL + "/api/test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != "test handler" {
+			t.Errorf("Expected body 'test handler', got '%s'", string(body))
+		}
+		if header := resp.Header.Get("X-Test-Middleware"); header != "true" {
+			t.Errorf("Expected header X-Test-Middleware to be 'true', got '%s'", header)
+		}
+	})
+
+	t.Run("GET /api/not-found", func(t *testing.T) {
+		resp, err := http.Get(testServer.URL + "/api/not-found")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("body: %s", body)
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("Expected status code %d, got %d", http.StatusNotFound, resp.StatusCode)
+		}
+
+		if header := resp.Header.Get("X-Test-Middleware"); header != "true" {
+			t.Errorf("Expected header X-Test-Middleware to be 'true', got '%s'", header)
+		}
+		if string(body) != "Custom 404: Page not found!\n" {
+			t.Errorf("Expected body 'Custom 404: Page not found!', got '%s'", string(body))
+		}
+	})
+
+	t.Run("GET /not-found", func(t *testing.T) {
+		resp, err := http.Get(testServer.URL + "/not-found")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("body: %s", body)
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("Expected status code %d, got %d", http.StatusNotFound, resp.StatusCode)
+		}
+		if header := resp.Header.Get("X-Test-Middleware"); header != "true" {
+			t.Errorf("Expected header X-Test-Middleware to be 'true', got '%s'", header)
+		}
+		if string(body) != "Custom 404: Page not found!\n" {
+			t.Errorf("Expected body 'Custom 404: Page not found!', got '%s'", string(body))
+		}
+	})
+}
+
+func TestHTTPServerWithCustomNotFoundNon404Status(t *testing.T) {
+	group := routegroup.New(http.NewServeMux())
+	group.Use(testMiddleware)
+	group.NotFoundHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("Custom 404: Page not found!\n"))
+	})
+
+	apiGroup := group.Mount("/api")
+	apiGroup.HandleFunc("GET /test", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("test handler"))
+	})
+
+	testServer := httptest.NewServer(group)
+	defer testServer.Close()
+
+	t.Run("GET /api/test", func(t *testing.T) {
+		resp, err := http.Get(testServer.URL + "/api/test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+		}
+		if string(body) != "test handler" {
+			t.Errorf("Expected body 'test handler', got '%s'", string(body))
+		}
+		if header := resp.Header.Get("X-Test-Middleware"); header != "true" {
+			t.Errorf("Expected header X-Test-Middleware to be 'true', got '%s'", header)
+		}
+	})
+
+	t.Run("GET /api/not-found", func(t *testing.T) {
+		resp, err := http.Get(testServer.URL + "/api/not-found")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("body: %s", body)
+
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Errorf("Expected status code %d, got %d", http.StatusServiceUnavailable, resp.StatusCode)
+		}
+		if header := resp.Header.Get("X-Test-Middleware"); header != "true" {
+			t.Errorf("Expected header X-Test-Middleware to be 'true', got '%s'", header)
+		}
+		if string(body) != "Custom 404: Page not found!\n" {
+			t.Errorf("Expected body 'Custom 404: Page not found!', got '%s'", string(body))
+		}
+	})
+
+}
+
 func ExampleNew() {
 	group := routegroup.New(http.NewServeMux())
 


### PR DESCRIPTION
The handler allows setting a custom response body for unregistered (not found) resources and also allows setting a custom status code.

see #9 