### PR TITLE
fix handling the root paths for serving files, add HandleFiles helper

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 linters-settings:
   govet:
-    check-shadowing: true
+    shadow: true
   gocyclo:
     min-complexity: 15
   maligned:
@@ -22,35 +22,38 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
+    - staticcheck
     - revive
     - govet
     - unconvert
-    - gas
+    - gosec
     - misspell
     - unparam
     - typecheck
     - ineffassign
     - stylecheck
     - gochecknoinits
-    - exportloopref
+    - copyloopvar
     - gocritic
     - nakedret
     - gosimple
     - prealloc
+    - unused
   fast: false
   disable-all: true
 
-run:
-  output:
-    format: tab
-  skip-dirs:
-    - vendor
 
+run:
+  concurrency: 4
 
 issues:
   exclude-rules:
     - text: "G114: Use of net/http serve function that has no support for setting timeouts"
       linters:
         - gosec
+    - linters:
+        - unparam
+        - revive
+      path: _test\.go$
+      text: "unused-parameter"
   exclude-use-default: false

--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ http.ListenAndServe(":8080", mux)
 
 In case you want to disable this behavior, you can use the `DisableNotFoundHandler()` function.
 
+### HandleFiles helper
+
+`routegroup` provides a helper function `HandleFiles` that can be used to serve static files from a directory. The function is a thin wrapper around the standard `http.FileServer` and can be used to serve files from a specific directory. Here's an example:
+
+```go
+// serve static files from the "assets/static" directory
+router.HandleFiles("/static/", http.Dir("assets/static"))
+```
 
 ## Real-world example
 

--- a/group.go
+++ b/group.go
@@ -185,8 +185,8 @@ func (b *Bundle) Route(configureFn func(*Bundle)) { configureFn(b) }
 
 // wrapMiddleware applies the registered middlewares to a handler.
 func (b *Bundle) wrapMiddleware(handler http.Handler) http.Handler {
-	for i := range b.middlewares {
-		handler = b.middlewares[len(b.middlewares)-1-i](handler)
+	for i := len(b.middlewares) - 1; i >= 0; i-- {
+		handler = b.middlewares[i](handler)
 	}
 	return handler
 }

--- a/group_test.go
+++ b/group_test.go
@@ -1,10 +1,13 @@
 package routegroup_test
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -66,6 +69,18 @@ func TestGroupHandle(t *testing.T) {
 		}
 		if body := recorder.Body.String(); body != "test handler" {
 			t.Errorf("Expected body 'test handler', got '%s'", body)
+		}
+	})
+
+	t.Run("handle, wrong method", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request, err := http.NewRequest(http.MethodPost, "/test2", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		group.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusNotFound {
+			t.Errorf("Expected status code %d, got %d", http.StatusNotFound, recorder.Code)
 		}
 	})
 
@@ -131,21 +146,58 @@ func TestGroupRoute(t *testing.T) {
 		g.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
+		g.HandleFunc("POST /test2", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
 	})
 
-	recorder := httptest.NewRecorder()
-	request, err := http.NewRequest(http.MethodGet, "/test", http.NoBody)
-	if err != nil {
-		t.Fatal(err)
-	}
-	group.ServeHTTP(recorder, request)
+	t.Run("GET /test", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request, err := http.NewRequest(http.MethodGet, "/test", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		group.ServeHTTP(recorder, request)
 
-	if recorder.Code != http.StatusOK {
-		t.Errorf("Expected status code %d, got %d", http.StatusOK, recorder.Code)
-	}
-	if header := recorder.Header().Get("X-Test-Middleware"); header != "true" {
-		t.Errorf("Expected header X-Test-Middleware to be 'true', got '%s'", header)
-	}
+		if recorder.Code != http.StatusOK {
+			t.Errorf("Expected status code %d, got %d", http.StatusOK, recorder.Code)
+		}
+		if header := recorder.Header().Get("X-Test-Middleware"); header != "true" {
+			t.Errorf("Expected header X-Test-Middleware to be 'true', got '%s'", header)
+		}
+	})
+
+	t.Run("POST /test2", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request, err := http.NewRequest(http.MethodPost, "/test2", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		group.ServeHTTP(recorder, request)
+
+		if recorder.Code != http.StatusOK {
+			t.Errorf("Expected status code %d, got %d", http.StatusOK, recorder.Code)
+		}
+		if header := recorder.Header().Get("X-Test-Middleware"); header != "true" {
+			t.Errorf("Expected header X-Test-Middleware to be 'true', got '%s'", header)
+		}
+	})
+
+	t.Run("GET /test2", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request, err := http.NewRequest(http.MethodGet, "/test2", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		group.ServeHTTP(recorder, request)
+
+		if recorder.Code != http.StatusNotFound {
+			t.Errorf("Expected status code %d, got %d", http.StatusNotFound, recorder.Code)
+		}
+		if header := recorder.Header().Get("X-Test-Middleware"); header != "true" {
+			t.Errorf("Expected header X-Test-Middleware to be 'true', got '%s'", header)
+		}
+	})
 }
 
 func TestGroupWithMiddleware(t *testing.T) {
@@ -169,6 +221,10 @@ func TestGroupWithMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
+	newGroup.HandleFunc("POST /with-test-post-only", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
 	t.Run("GET /with-test", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		request, err := http.NewRequest(http.MethodGet, "/with-test", http.NoBody)
@@ -188,9 +244,66 @@ func TestGroupWithMiddleware(t *testing.T) {
 		}
 	})
 
+	t.Run("POST /with-test", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request, err := http.NewRequest(http.MethodPost, "/with-test", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		group.ServeHTTP(recorder, request)
+
+		if recorder.Code != http.StatusOK {
+			t.Errorf("Expected status code %d, got %d", http.StatusOK, recorder.Code)
+		}
+		if header := recorder.Header().Get("X-Original-Middleware"); header != "true" {
+			t.Errorf("Expected header X-Original-Middleware to be 'true', got '%s'", header)
+		}
+		if header := recorder.Header().Get("X-New-Middleware"); header != "true" {
+			t.Errorf("Expected header X-New-Middleware to be 'true', got '%s'", header)
+		}
+	})
+
 	t.Run("GET /not-found", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		request, err := http.NewRequest(http.MethodGet, "/not-found", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		group.ServeHTTP(recorder, request)
+
+		if recorder.Code != http.StatusNotFound {
+			t.Errorf("Expected status code %d, got %d", http.StatusNotFound, recorder.Code)
+		}
+		if header := recorder.Header().Get("X-Original-Middleware"); header != "true" {
+			t.Errorf("Expected header X-Original-Middleware to be 'true', got '%s'", header)
+		}
+		if header := recorder.Header().Get("X-New-Middleware"); header != "" {
+			t.Errorf("Expected header X-New-Middleware to be not set, got '%s'", header)
+		}
+	})
+
+	t.Run("POST /with-test-post-only", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request, err := http.NewRequest(http.MethodPost, "/with-test-post-only", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		group.ServeHTTP(recorder, request)
+
+		if recorder.Code != http.StatusOK {
+			t.Errorf("Expected status code %d, got %d", http.StatusOK, recorder.Code)
+		}
+		if header := recorder.Header().Get("X-Original-Middleware"); header != "true" {
+			t.Errorf("Expected header X-Original-Middleware to be 'true', got '%s'", header)
+		}
+		if header := recorder.Header().Get("X-New-Middleware"); header != "true" {
+			t.Errorf("Expected header X-New-Middleware to be 'true', got '%s'", header)
+		}
+	})
+
+	t.Run("GET /with-test-post-only", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request, err := http.NewRequest(http.MethodGet, "/with-test-post-only", http.NoBody)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1283,6 +1396,758 @@ func TestMountNested(t *testing.T) {
 	if rec.Body.String() != "v1 test" {
 		t.Errorf("got %q, want %q", rec.Body.String(), "v1 test")
 	}
+}
+
+func TestStaticFileServer(t *testing.T) {
+	dir := t.TempDir()
+
+	// create test file structure
+	content := []byte("static file content")
+	err := os.WriteFile(filepath.Join(dir, "test.txt"), content, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(dir, "index.html"), []byte("index content"), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create subdirectory
+	subDir := filepath.Join(dir, "sub")
+	if err = os.Mkdir(subDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	subContent := []byte("sub file content")
+	err = os.WriteFile(filepath.Join(subDir, "sub.txt"), subContent, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("serve files from root path with HEAD", func(t *testing.T) {
+		router := routegroup.New(http.NewServeMux())
+		router.HandleFiles("/", http.Dir(dir))
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		// test GET request
+		resp, err := http.Get(srv.URL + "/test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET - got status %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if !bytes.Equal(body, content) {
+			t.Errorf("GET - got body %q, want %q", body, content)
+		}
+
+		// test HEAD request
+		req, err := http.NewRequest(http.MethodHead, srv.URL+"/test.txt", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("HEAD - got status %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if len(body) != 0 {
+			t.Errorf("HEAD - should have no body, got %d bytes", len(body))
+		}
+		if cl := resp.Header.Get("Content-Length"); cl != fmt.Sprint(len(content)) {
+			t.Errorf("HEAD - got Content-Length %s, want %d", cl, len(content))
+		}
+	})
+
+	t.Run("serve files from /files/ prefix", func(t *testing.T) {
+		router := routegroup.New(http.NewServeMux())
+		router.HandleFiles("/files", http.Dir(dir))
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		// test GET request
+		resp, err := http.Get(srv.URL + "/files/test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET - got status %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if !bytes.Equal(body, content) {
+			t.Errorf("GET - got body %q, want %q", body, content)
+		}
+
+		// test HEAD request
+		req, err := http.NewRequest(http.MethodHead, srv.URL+"/files/test.txt", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("HEAD - got status %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if len(body) != 0 {
+			t.Errorf("HEAD - should have no body, got %d bytes", len(body))
+		}
+		if cl := resp.Header.Get("Content-Length"); cl != fmt.Sprint(len(content)) {
+			t.Errorf("HEAD - got Content-Length %s, want %d", cl, len(content))
+		}
+	})
+
+	t.Run("serve files from mounted group", func(t *testing.T) {
+		router := routegroup.New(http.NewServeMux())
+		assets := router.Mount("/assets")
+		assets.HandleFiles("/", http.Dir(dir))
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		// test GET request
+		resp, err := http.Get(srv.URL + "/assets/test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET - got status %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if !bytes.Equal(body, content) {
+			t.Errorf("GET - got body %q, want %q", body, content)
+		}
+
+		// test HEAD request
+		req, err := http.NewRequest(http.MethodHead, srv.URL+"/assets/test.txt", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("HEAD - got status %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if len(body) != 0 {
+			t.Errorf("HEAD - should have no body, got %d bytes", len(body))
+		}
+		if cl := resp.Header.Get("Content-Length"); cl != fmt.Sprint(len(content)) {
+			t.Errorf("HEAD - got Content-Length %s, want %d", cl, len(content))
+		}
+	})
+}
+
+func TestDirectFileServerHandle(t *testing.T) {
+	dir := t.TempDir()
+
+	content := []byte("static file content")
+	err := os.WriteFile(filepath.Join(dir, "test.txt"), content, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("raw Handle without strip", func(t *testing.T) {
+		router := routegroup.New(http.NewServeMux())
+		router.Handle("/files/", http.FileServer(http.Dir(dir))) // without StripPrefix!
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		// test GET request - should fail as we need StripPrefix
+		resp, err := http.Get(srv.URL + "/files/test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected 404 without StripPrefix, got %d", resp.StatusCode)
+		}
+
+		// test HEAD request - should also fail
+		req, err := http.NewRequest(http.MethodHead, srv.URL+"/files/test.txt", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("HEAD - expected 404 without StripPrefix, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Handle with strip prefix", func(t *testing.T) {
+		router := routegroup.New(http.NewServeMux())
+		router.Handle("/files/", http.StripPrefix("/files/", http.FileServer(http.Dir(dir))))
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		// test GET request
+		resp, err := http.Get(srv.URL + "/files/test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET - got status %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if !bytes.Equal(body, content) {
+			t.Errorf("GET - got body %q, want %q", body, content)
+		}
+
+		// test HEAD request
+		req, err := http.NewRequest(http.MethodHead, srv.URL+"/files/test.txt", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("HEAD - got status %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if len(body) != 0 {
+			t.Errorf("HEAD - should have no body, got %d bytes", len(body))
+		}
+		if cl := resp.Header.Get("Content-Length"); cl != fmt.Sprint(len(content)) {
+			t.Errorf("HEAD - got Content-Length %s, want %d", cl, len(content))
+		}
+	})
+
+	t.Run("Handle with mounted group", func(t *testing.T) {
+		router := routegroup.New(http.NewServeMux())
+		api := router.Mount("/api")
+		api.Handle("/static/", http.StripPrefix("/api/static/", http.FileServer(http.Dir(dir))))
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		// test GET request
+		resp, err := http.Get(srv.URL + "/api/static/test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET - got status %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if !bytes.Equal(body, content) {
+			t.Errorf("GET - got body %q, want %q", body, content)
+		}
+
+		// test HEAD request
+		req, err := http.NewRequest(http.MethodHead, srv.URL+"/api/static/test.txt", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("HEAD - got status %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if len(body) != 0 {
+			t.Errorf("HEAD - should have no body, got %d bytes", len(body))
+		}
+		if cl := resp.Header.Get("Content-Length"); cl != fmt.Sprint(len(content)) {
+			t.Errorf("HEAD - got Content-Length %s, want %d", cl, len(content))
+		}
+	})
+}
+
+func TestFileServerWithMiddleware(t *testing.T) {
+	dir := t.TempDir()
+
+	content := []byte("static file content")
+	err := os.WriteFile(filepath.Join(dir, "test.txt"), content, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("root path with middleware", func(t *testing.T) {
+		router := routegroup.New(http.NewServeMux())
+		router.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Root-MW", "called")
+				next.ServeHTTP(w, r)
+			})
+		})
+		router.HandleFiles("/", http.Dir(dir))
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		// test GET request
+		resp, err := http.Get(srv.URL + "/test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if mw := resp.Header.Get("X-Root-MW"); mw != "called" {
+			t.Errorf("middleware not called, got header %q", mw)
+		}
+
+		// test HEAD request
+		req, err := http.NewRequest(http.MethodHead, srv.URL+"/test.txt", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if mw := resp.Header.Get("X-Root-MW"); mw != "called" {
+			t.Errorf("middleware not called for HEAD, got header %q", mw)
+		}
+	})
+
+	t.Run("prefixed path with middleware", func(t *testing.T) {
+		router := routegroup.New(http.NewServeMux())
+		router.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Prefix-MW", "called")
+				next.ServeHTTP(w, r)
+			})
+		})
+		router.HandleFiles("/files", http.Dir(dir))
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		resp, err := http.Get(srv.URL + "/files/test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if mw := resp.Header.Get("X-Prefix-MW"); mw != "called" {
+			t.Errorf("middleware not called, got header %q", mw)
+		}
+	})
+
+	t.Run("mounted path with chained middleware", func(t *testing.T) {
+		router := routegroup.New(http.NewServeMux())
+		router.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Root-MW", "called")
+				next.ServeHTTP(w, r)
+			})
+		})
+
+		assets := router.Mount("/assets")
+		assets.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Assets-MW", "called")
+				next.ServeHTTP(w, r)
+			})
+		})
+		assets.HandleFiles("/", http.Dir(dir))
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		// test both middleware being called
+		resp, err := http.Get(srv.URL + "/assets/test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if mw := resp.Header.Get("X-Root-MW"); mw != "called" {
+			t.Errorf("root middleware not called, got header %q", mw)
+		}
+		if mw := resp.Header.Get("X-Assets-MW"); mw != "called" {
+			t.Errorf("assets middleware not called, got header %q", mw)
+		}
+
+		// test 404 path still triggers middleware
+		resp, err = http.Get(srv.URL + "/assets/notfound.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("got status %d, want %d", resp.StatusCode, http.StatusNotFound)
+		}
+		if mw := resp.Header.Get("X-Root-MW"); mw != "called" {
+			t.Errorf("root middleware not called for 404, got header %q", mw)
+		}
+		if mw := resp.Header.Get("X-Assets-MW"); mw != "called" {
+			t.Errorf("assets middleware not called for 404, got header %q", mw)
+		}
+	})
+
+	t.Run("direct Handle with middleware", func(t *testing.T) {
+		router := routegroup.New(http.NewServeMux())
+		router.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Direct-MW", "called")
+				next.ServeHTTP(w, r)
+			})
+		})
+		router.Handle("/files/", http.StripPrefix("/files/", http.FileServer(http.Dir(dir))))
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		resp, err := http.Get(srv.URL + "/files/test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if mw := resp.Header.Get("X-Direct-MW"); mw != "called" {
+			t.Errorf("middleware not called, got header %q", mw)
+		}
+	})
+}
+
+func TestMixedHandlers(t *testing.T) {
+	dir := t.TempDir()
+
+	// create static files
+	content := []byte("static file content")
+	err := os.WriteFile(filepath.Join(dir, "test.txt"), content, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router := routegroup.New(http.NewServeMux())
+
+	// setup regular and file handlers in various combinations
+	router.HandleFunc("GET /api/info", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("api info"))
+	})
+	router.HandleFiles("/public", http.Dir(dir))
+
+	// setup api group with mixed handlers
+	api := router.Mount("/v1")
+	api.HandleFunc("GET /data", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("api data"))
+	})
+	api.HandleFiles("/static", http.Dir(dir))
+
+	// setup admin group with both types and middleware
+	admin := router.Mount("/admin")
+	admin.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Admin", "true")
+			next.ServeHTTP(w, r)
+		})
+	})
+	admin.HandleFunc("GET /users", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("admin users"))
+	})
+	admin.HandleFiles("/assets", http.Dir(dir))
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	tests := []struct {
+		name           string
+		path           string
+		expectedStatus int
+		expectedBody   string
+		expectedHeader string // for middleware check
+	}{
+		{"api info endpoint", "/api/info", http.StatusOK, "api info", ""},
+		{"public static file", "/public/test.txt", http.StatusOK, "static file content", ""},
+		{"v1 api endpoint", "/v1/data", http.StatusOK, "api data", ""},
+		{"v1 static file", "/v1/static/test.txt", http.StatusOK, "static file content", ""},
+		{"admin endpoint", "/admin/users", http.StatusOK, "admin users", "true"},
+		{"admin static file", "/admin/assets/test.txt", http.StatusOK, "static file content", "true"},
+		{"non-existent api path", "/api/notfound", http.StatusNotFound, "404 page not found\n", ""},
+		{"non-existent static file", "/public/notfound.txt", http.StatusNotFound, "404 page not found\n", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.Get(srv.URL + tt.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if resp.StatusCode != tt.expectedStatus {
+				t.Errorf("got status %d, want %d", resp.StatusCode, tt.expectedStatus)
+			}
+
+			if string(body) != tt.expectedBody {
+				t.Errorf("got body %q, want %q", string(body), tt.expectedBody)
+			}
+
+			if tt.expectedHeader != "" {
+				if h := resp.Header.Get("X-Admin"); h != tt.expectedHeader {
+					t.Errorf("got X-Admin header %q, want %q", h, tt.expectedHeader)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleTrailingSlash(t *testing.T) {
+	router := routegroup.New(http.NewServeMux())
+
+	t.Run("handler for pattern with trailing slash", func(t *testing.T) {
+		router.Handle("/path/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("handler with trailing slash"))
+		}))
+		router.HandleFunc("GET /path/sub", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("sub handler"))
+		})
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		tests := []struct {
+			name       string
+			method     string
+			path       string
+			wantStatus int
+			wantBody   string
+		}{
+			{"GET /path/", http.MethodGet, "/path/", http.StatusOK, "handler with trailing slash"},
+			{"POST /path/", http.MethodPost, "/path/", http.StatusOK, "handler with trailing slash"},
+			{"GET /path/sub", http.MethodGet, "/path/sub", http.StatusOK, "sub handler"},                   // more specific route wins
+			{"POST /path/sub", http.MethodPost, "/path/sub", http.StatusOK, "handler with trailing slash"}, // falls back to /path/
+			{"GET /path/anything", http.MethodGet, "/path/anything", http.StatusOK, "handler with trailing slash"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				req, err := http.NewRequest(tt.method, srv.URL+tt.path, http.NoBody)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer resp.Body.Close()
+
+				if resp.StatusCode != tt.wantStatus {
+					t.Errorf("got status %d, want %d", resp.StatusCode, tt.wantStatus)
+				}
+
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if got := string(body); got != tt.wantBody {
+					t.Errorf("got body %q, want %q", got, tt.wantBody)
+				}
+			})
+		}
+	})
+
+	t.Run("mounted handler with trailing slash", func(t *testing.T) {
+		api := router.Mount("/api")
+		api.Handle("/v1/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("api v1"))
+		}))
+		api.HandleFunc("GET /v1/data", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("api data"))
+		})
+
+		srv := httptest.NewServer(router)
+		defer srv.Close()
+
+		tests := []struct {
+			name       string
+			method     string
+			path       string
+			wantStatus int
+			wantBody   string
+		}{
+			{"GET /api/v1/", http.MethodGet, "/api/v1/", http.StatusOK, "api v1"},
+			{"POST /api/v1/", http.MethodPost, "/api/v1/", http.StatusOK, "api v1"},
+			{"GET /api/v1/data", http.MethodGet, "/api/v1/data", http.StatusOK, "api data"}, // more specific route wins
+			{"POST /api/v1/data", http.MethodPost, "/api/v1/data", http.StatusOK, "api v1"}, // falls back to /v1/
+			{"GET /api/v1/anything", http.MethodGet, "/api/v1/anything", http.StatusOK, "api v1"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				req, err := http.NewRequest(tt.method, srv.URL+tt.path, http.NoBody)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer resp.Body.Close()
+
+				if resp.StatusCode != tt.wantStatus {
+					t.Errorf("got status %d, want %d", resp.StatusCode, tt.wantStatus)
+				}
+
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if got := string(body); got != tt.wantBody {
+					t.Errorf("got body %q, want %q", got, tt.wantBody)
+				}
+			})
+		}
+	})
+}
+
+func TestIssue12StaticAndIndex(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "test.txt"), []byte("static content"), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router := routegroup.New(http.NewServeMux())
+	router.Route(func(base *routegroup.Bundle) {
+		base.Handle("/", http.FileServer(http.Dir(dir)))
+		base.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("index page"))
+		})
+		base.HandleFunc("GET /login", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("login page"))
+		})
+	})
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	t.Run("serve static file", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got := string(body); got != "static content" {
+			t.Errorf("got %q, want static content", got)
+		}
+	})
+
+	t.Run("serve index", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got := string(body); got != "index page" {
+			t.Errorf("got %q, want index page", got)
+		}
+	})
+
+	t.Run("serve login page", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/login")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got := string(body); got != "login page" {
+			t.Errorf("got %q, want login page", got)
+		}
+	})
 }
 
 func ExampleNew() {


### PR DESCRIPTION
Related to #12 

The PR adds a proper treatment of registered root path to handle file serving properly in this case. A special case was added to cover the exact scenario described in the ticket (`TestIssue12StaticAndIndex`)

In addition, I have added a small helper `HandleFiles` to make the mounting of the FileSystem easier and more direct. I was reluctant to create this method before as it introduces a non-stdlib compatible extension to the handling; however, I decided to do it because mounting filesystems is a common source of issues with incorrect stripping, missing/extra slashes, and so on. At the same time, the traditional (i.e., direct) way to achieve it is still available.

The fact that my tests missed #12 made me extend the coverage significantly and add a bunch of extra test cases to ensure it is testing all the cases I can think of.