### PR TITLE
Add HandleRoot method to handle group root paths without redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,36 @@ You can also apply middleware to specific routes inside the group without modify
 apiGroup.With(corsMiddleware, apiMiddleware).Handle("GET /hello", helloHandler)
 ```
 
+**Handling Root Paths Without Trailing Slashes**
+
+When working with mounted groups, you often need to handle requests to the group's root path without a trailing slash. For this purpose, `routegroup` provides the `HandleRoot` method:
+
+```go
+// Create mounted groups
+apiGroup := router.Mount("/api")
+v1Group := apiGroup.Mount("/v1")
+usersGroup := v1Group.Mount("/users")
+
+// Handle the root paths (no trailing slashes)
+apiGroup.HandleRoot("GET", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    // This handles requests to "/api" (without trailing slash)
+    w.Write([]byte("API Documentation"))
+}))
+
+usersGroup.HandleRoot("GET", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    // This handles requests to "/api/v1/users" (without trailing slash)
+    w.Write([]byte("List users"))
+}))
+
+// Different HTTP methods can be handled separately
+usersGroup.HandleRoot("POST", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    // This handles POST requests to "/api/v1/users"
+    w.Write([]byte("Create user"))
+}))
+```
+
+While it's also possible to handle such paths using a trailing slash pattern (`"/"`) with the regular `Handle` or `HandleFunc` methods, that approach results in a redirect from non-trailing slash URLs (e.g., `/api`) to the trailing slash version (e.g., `/api/`). The `HandleRoot` method avoids this redirect, providing a more direct response and avoiding an extra round-trip, which is especially important for non-GET requests or when clients don't automatically follow redirects.
+
 **Alternative Usage with `Route`**
 
 You can also use the `Route` method to add routes and middleware in a single function call:

--- a/group.go
+++ b/group.go
@@ -165,6 +165,27 @@ func (b *Bundle) register(pattern string, handler http.HandlerFunc) {
 // Route allows for configuring the Group inside the configureFn function.
 func (b *Bundle) Route(configureFn func(*Bundle)) { configureFn(b) }
 
+// HandleRoot adds a handler for the group's root path (no trailing slash).
+// This method is needed to handle requests to a group's root path without causing redirects that would occur with trailing slash patterns.
+// Unlike registering a pattern with "/", which causes the standard ServeMux to redirect non-trailing slash requests to the trailing slash
+// version (301 Moved Permanently), HandleRoot registers the exact path without any special treatment,
+// avoiding the redirect behavior while still applying middleware.
+// Method parameter can be empty; in this case, the handler will be registered for all methods.
+func (b *Bundle) HandleRoot(method string, handler http.Handler) {
+	// for empty base path, use "/" to match the root
+	pattern := b.basePath
+	if pattern == "" {
+		pattern = "/"
+	}
+
+	// add method if specified
+	if method != "" {
+		pattern = method + " " + pattern
+	}
+
+	b.mux.Handle(pattern, b.wrapMiddleware(handler))
+}
+
 // wrapMiddleware applies the registered middlewares to a handler.
 func (b *Bundle) wrapMiddleware(handler http.Handler) http.Handler {
 	for i := len(b.middlewares) - 1; i >= 0; i-- {


### PR DESCRIPTION
## Summary
- Adds a new  method to handle requests to a group's root path without trailing slashes
- Avoids redirects that would occur when using standard trailing slash patterns with Handle or HandleFunc
- Allows specifying an HTTP method or handling all methods if left empty
- Includes comprehensive tests and documentation updates

## Solution Details
This PR addresses issue #16 by adding a dedicated method for handling root paths of mounted groups without causing redirects. Unlike registering patterns with a trailing slash, which causes the standard ServeMux to redirect non-trailing slash requests to the trailing slash version (301 Moved Permanently), the new  method registers the exact path without special treatment, avoiding redirect behavior while still applying the group's middleware.

Fixes #16