### PR TITLE
Fix CI workflow: checkout before setup-go for proper caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: set up go 1.23
-        uses: actions/setup-go@v3
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: set up go
+        uses: actions/setup-go@v5
         with:
           go-version: "1.23"
         id: go
-
-      - name: checkout
-        uses: actions/checkout@v3
 
       - name: build and test
         run: |
@@ -36,7 +36,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          version: v2.6
 
       - name: install goveralls
         run: |

--- a/group.go
+++ b/group.go
@@ -182,6 +182,7 @@ func (b *Bundle) Handler(r *http.Request) (h http.Handler, pattern string) {
 }
 
 // DisableNotFoundHandler used to disable auto-registration of a catch-all 404.
+//
 // Deprecated: now a no-op retained for API compatibility.
 func (b *Bundle) DisableNotFoundHandler() {}
 


### PR DESCRIPTION
## Summary
- Move checkout step before setup-go to enable proper Go module caching
- setup-go needs go.mod/go.sum files to generate cache keys, which don't exist until checkout
- Update actions to latest versions (checkout@v4, setup-go@v5)
- Use golangci-lint version 2.6
- Fix deprecation comment formatting (gocritic warning)